### PR TITLE
Fix remote code execution #1

### DIFF
--- a/generate.php
+++ b/generate.php
@@ -1,3 +1,3 @@
 <?php
-	echo shell_exec("python algorithm.py " . $_GET["input"])
+	echo shell_exec("python algorithm.py " . escapeshellarg($_GET["input"]))
 ?>


### PR DESCRIPTION
Fix a remote shell command injection bug. I could execute the `id` command by doing the following:

```
GET /generate.php?input=;id
```

Always escape shell arguments.